### PR TITLE
Rename JSC to jsc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/lib/jscheck.js
+++ b/lib/jscheck.js
@@ -744,7 +744,7 @@ module.exports = (function () {
                 };
             },
             test: function (name, predicate, signature, classifier, ms) {
-                return JSC.check(JSC.claim(name, predicate, signature,
+                return jsc.check(jsc.claim(name, predicate, signature,
                     classifier, true), ms);
             }
         };

--- a/lib/jscheck.js
+++ b/lib/jscheck.js
@@ -18,9 +18,14 @@
     slice, sort, string, stringify, test, total, verdict
 */
 
-
-module.exports = (function () {
+var _jsc = function (options) {
     'use strict';
+
+    var random = options && options.random;
+
+    if (typeof random !== 'function') {
+      throw new Error("Invalid random function not passed to jsc");
+    }
 
     var all,            // The collection of all claims
         any,            // The generator of any value,
@@ -71,6 +76,9 @@ module.exports = (function () {
         },
 
         jsc = {
+            configure: function(options) {
+                return _jsc(options);
+            },
             any: function () {
                 return jsc.one_of(any);
             },
@@ -110,7 +118,7 @@ module.exports = (function () {
                     bias = 0.50;
                 }
                 return function () {
-                    return Math.random() < bias;
+                    return random() < bias;
                 };
             },
             character: function character(i, j) {
@@ -556,7 +564,7 @@ module.exports = (function () {
                     j = t;
                 }
                 return function () {
-                    return Math.floor(Math.random() * (j + 1 - i) + i);
+                    return Math.floor(random() * (j + 1 - i) + i);
                 };
             },
             literal: function (value) {
@@ -580,7 +588,7 @@ module.exports = (function () {
                     j = t;
                 }
                 return function () {
-                    return Math.random() * (j - i) + i;
+                    return random() * (j - i) + i;
                 };
             },
             object: function (object, value) {
@@ -638,14 +646,14 @@ module.exports = (function () {
 
                 if (typeof array === 'string') {
                     return function () {
-                        return array.charAt(Math.floor(Math.random() *
+                        return array.charAt(Math.floor(random() *
                             array.length));
                     };
                 }
                 if (Array.isArray(array) && array.length > 0) {
                     if (!Array.isArray(weights)) {
                         return function () {
-                            return resolve(array[Math.floor(Math.random() *
+                            return resolve(array[Math.floor(random() *
                                 array.length)]);
                         };
                     }
@@ -660,7 +668,7 @@ module.exports = (function () {
                                 return base;
                             });
                         return function () {
-                            var i, x = Math.random();
+                            var i, x = random();
                             for (i = 0; i < n; i += 1) {
                                 if (x < list[i]) {
                                     return resolve(array[i]);
@@ -753,4 +761,8 @@ module.exports = (function () {
         jsc.string(), true, Infinity, -Infinity
     ];
     return jsc.clear();
-}());
+};
+
+module.exports = _jsc({
+  random: function() { return Math.random.apply(this, arguments); }
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jscheck",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Douglas Crockford's port of QuickCheck to JavaScript",
   "main": "lib/jscheck.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,19 +1,20 @@
 {
-  "name": "js-quick-check",
+  "name": "jscheck",
   "version": "0.1.0",
   "description": "Douglas Crockford's port of QuickCheck to JavaScript",
   "main": "lib/jscheck.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/AndrewRademacher/JSCheck.git"
+    "url": "git://github.com/tristanstraub/JSCheck.git"
   },
   "author": "Douglas Crockford",
+  "contributors": [
+    "Andrew Rademacher",
+    "Tristan Straub <tristan@straub.id.au> allthethings.io"
+  ],
   "license": "Public Domain",
   "bugs": {
-    "url": "https://github.com/AndrewRademacher/JSCheck/issues"
+    "url": "https://github.com/tristanstraub/JSCheck/issues"
   },
-  "homepage": "https://github.com/AndrewRademacher/JSCheck"
+  "homepage": "https://github.com/tristanstraub/JSCheck"
 }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,11 @@
   "bugs": {
     "url": "https://github.com/tristanstraub/JSCheck/issues"
   },
-  "homepage": "https://github.com/tristanstraub/JSCheck"
+  "homepage": "https://github.com/tristanstraub/JSCheck",
+  "scripts": {
+    "test": "mocha --recursive test"
+  },
+  "devDependencies": {
+    "mocha": "^1.21.3"
+  }
 }

--- a/test/lib/jscheck-test.js
+++ b/test/lib/jscheck-test.js
@@ -1,0 +1,26 @@
+var jscheck = require('../../lib/jscheck');
+var assert = require('assert');
+
+describe('jscheck', function() {
+  it('can be seeded with a random number generator', function() {
+    var next, gen;
+    var nextRandomNumber = 1;
+    var n = 10;
+
+    var jsc = jscheck.configure({
+      random: function() {
+        return nextRandomNumber++;
+      }
+    });
+
+    while(n--) {
+      next = 10 * nextRandomNumber + 1;
+      gen = jsc.integer(10);
+      if (typeof gen === 'function') {
+        assert.equal(gen(), next);
+      } else {
+        assert.equal(gen, next);
+      }
+    }
+  });
+});


### PR DESCRIPTION
It wouldn't run in nodejs or browserify, because uppercase JSC isn't defined locally.